### PR TITLE
remove authdigest_shm files on startup

### DIFF
--- a/start-apache.sh
+++ b/start-apache.sh
@@ -6,6 +6,9 @@ if [ -e /var/run/httpd/httpd.pid ]; then
   rm -f /var/run/httpd/httpd.pid
 fi
 
+# Remove shared memory files that prevent apache from starting
+rm -f /var/run/httpd/authdigest_shm.*
+
 # Run apache in foreground
 echo "Starting httpd"
 /usr/sbin/apachectl -DFOREGROUND


### PR DESCRIPTION
We think these files may be related to shibboleth apache configuration specific to this deployment because we haven't seen this issue in other apache servers hosted inside docker.
Fixes #4 
